### PR TITLE
refactor: removing end of file token

### DIFF
--- a/src/lexical_analysis/mod.rs
+++ b/src/lexical_analysis/mod.rs
@@ -77,7 +77,6 @@ impl<'a> LexicalAnalysis<'a> {
                 None => {
                     debug!("End of the source code.");
                     parse_context!(tokens, context);
-                    add_token!(tokens, Token::EndOfFile);
                     break;
                 }
             }

--- a/src/lexical_analysis/model/token/mod.rs
+++ b/src/lexical_analysis/model/token/mod.rs
@@ -1,7 +1,5 @@
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Token {
-    EndOfFile,
-
     // Identifiers
     Identifier { literal: String },
 

--- a/src/syntax_analysis/expression/utilities/mod.rs
+++ b/src/syntax_analysis/expression/utilities/mod.rs
@@ -15,7 +15,7 @@ impl<'a> SyntaxAnalysis<'a> {
 
         while let Some(token) = self.tokens.peek() {
             match token {
-                Token::ClosingCurlyBracket | Token::EndOfFile => break,
+                Token::ClosingCurlyBracket => break,
                 _ => {
                     blocks.push(self.get_next_syntax_tree_node()?);
                 }

--- a/src/syntax_analysis/mod.rs
+++ b/src/syntax_analysis/mod.rs
@@ -29,14 +29,9 @@ impl<'a> SyntaxAnalysis<'a> {
     pub(crate) fn get_abstract_syntax_tree(&mut self) -> Result<Vec<SyntaxTreeNode>, SyntaxError> {
         let mut abstract_syntax_tree: Vec<SyntaxTreeNode> = vec![];
 
-        while let Some(token) = self.tokens.peek() {
-            match token {
-                Token::EndOfFile => break,
-                _ => {
-                    let syntax_tree_node = self.get_next_syntax_tree_node()?;
-                    abstract_syntax_tree.push(syntax_tree_node)
-                }
-            }
+        while self.tokens.peek().is_some() {
+            let syntax_tree_node = self.get_next_syntax_tree_node()?;
+            abstract_syntax_tree.push(syntax_tree_node)
         }
 
         Ok(abstract_syntax_tree)

--- a/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_1_lexical_analysis.snap
+++ b/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_1_lexical_analysis.snap
@@ -4,5 +4,4 @@ expression: tokens
 ---
 [
     False,
-    EndOfFile,
 ]

--- a/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_2_lexical_analysis.snap
+++ b/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_2_lexical_analysis.snap
@@ -4,5 +4,4 @@ expression: tokens
 ---
 [
     False,
-    EndOfFile,
 ]

--- a/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_3_lexical_analysis.snap
+++ b/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_3_lexical_analysis.snap
@@ -4,5 +4,4 @@ expression: tokens
 ---
 [
     True,
-    EndOfFile,
 ]

--- a/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_4_lexical_analysis.snap
+++ b/src/tests/boolean_expression/snapshots/monkey_interpreter__tests__boolean_expression__test_boolean_expression_case_4_lexical_analysis.snap
@@ -4,5 +4,4 @@ expression: tokens
 ---
 [
     True,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_1_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     True,
     Equals,
     True,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_2_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     False,
     Equals,
     False,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_3_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     True,
     Equals,
     False,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_4_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_4_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     False,
     Equals,
     True,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_5_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_5_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     True,
     NotEquals,
     False,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_6_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_6_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     False,
     NotEquals,
     True,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_7_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_7_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     True,
     NotEquals,
     True,
-    EndOfFile,
 ]

--- a/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_8_lexical_analysis.snap
+++ b/src/tests/boolean_infix_expression/snapshots/monkey_interpreter__tests__boolean_infix_expression__test_boolean_infix_expression_case_8_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     False,
     NotEquals,
     False,
-    EndOfFile,
 ]

--- a/src/tests/boolean_prefix_expression/snapshots/monkey_interpreter__tests__boolean_prefix_expression__test_boolean_prefix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/boolean_prefix_expression/snapshots/monkey_interpreter__tests__boolean_prefix_expression__test_boolean_prefix_expression_case_1_lexical_analysis.snap
@@ -5,5 +5,4 @@ expression: tokens
 [
     Not,
     False,
-    EndOfFile,
 ]

--- a/src/tests/boolean_prefix_expression/snapshots/monkey_interpreter__tests__boolean_prefix_expression__test_boolean_prefix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/boolean_prefix_expression/snapshots/monkey_interpreter__tests__boolean_prefix_expression__test_boolean_prefix_expression_case_2_lexical_analysis.snap
@@ -5,5 +5,4 @@ expression: tokens
 [
     Not,
     True,
-    EndOfFile,
 ]

--- a/src/tests/boolean_prefix_expression/snapshots/monkey_interpreter__tests__boolean_prefix_expression__test_boolean_prefix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/boolean_prefix_expression/snapshots/monkey_interpreter__tests__boolean_prefix_expression__test_boolean_prefix_expression_case_3_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     Not,
     Not,
     True,
-    EndOfFile,
 ]

--- a/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_1_lexical_analysis.snap
+++ b/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_1_lexical_analysis.snap
@@ -21,5 +21,4 @@ expression: tokens
     },
     ClosingRoundBracket,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_2_lexical_analysis.snap
+++ b/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_2_lexical_analysis.snap
@@ -22,5 +22,4 @@ expression: tokens
     },
     ClosingRoundBracket,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_3_lexical_analysis.snap
+++ b/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_3_lexical_analysis.snap
@@ -24,5 +24,4 @@ expression: tokens
     },
     ClosingRoundBracket,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_4_lexical_analysis.snap
+++ b/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_4_lexical_analysis.snap
@@ -32,5 +32,4 @@ expression: tokens
     },
     ClosingRoundBracket,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_5_lexical_analysis.snap
+++ b/src/tests/call_expression/snapshots/monkey_interpreter__tests__call_expression__test_call_expression_case_5_lexical_analysis.snap
@@ -50,5 +50,4 @@ expression: tokens
     ClosingRoundBracket,
     ClosingRoundBracket,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/code_samples/snapshots/monkey_interpreter__tests__code_samples__test_factorial_lexical_analysis.snap
+++ b/src/tests/code_samples/snapshots/monkey_interpreter__tests__code_samples__test_factorial_lexical_analysis.snap
@@ -85,5 +85,4 @@ expression: tokens
         literal: 9,
     },
     ClosingRoundBracket,
-    EndOfFile,
 ]

--- a/src/tests/edge_cases/snapshots/monkey_interpreter__tests__edge_cases__test_edge_case_1_lexical_analysis.snap
+++ b/src/tests/edge_cases/snapshots/monkey_interpreter__tests__edge_cases__test_edge_case_1_lexical_analysis.snap
@@ -2,6 +2,4 @@
 source: src/tests/edge_cases/mod.rs
 expression: tokens
 ---
-[
-    EndOfFile,
-]
+[]

--- a/src/tests/evaluation_error/type_mismatch_boolean_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_infix_expression__test_type_mismatch_boolean_infix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_boolean_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_infix_expression__test_type_mismatch_boolean_infix_expression_case_1_lexical_analysis.snap
@@ -16,5 +16,4 @@ expression: tokens
     Integer {
         literal: 5,
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_boolean_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_infix_expression__test_type_mismatch_boolean_infix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_boolean_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_infix_expression__test_type_mismatch_boolean_infix_expression_case_2_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     },
     Equals,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_boolean_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_infix_expression__test_type_mismatch_boolean_infix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_boolean_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_infix_expression__test_type_mismatch_boolean_infix_expression_case_3_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "this is a string",
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_1_lexical_analysis.snap
@@ -5,5 +5,4 @@ expression: tokens
 [
     Minus,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_2_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     Minus,
     True,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_3_lexical_analysis.snap
@@ -5,5 +5,4 @@ expression: tokens
 [
     Minus,
     False,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_4_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_boolean_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_boolean_prefix_expression__test_type_mismatch_boolean_prefix_expression_case_4_lexical_analysis.snap
@@ -5,5 +5,4 @@ expression: tokens
 [
     Minus,
     False,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_10_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_10_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 10,
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_11_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_11_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 7,
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_12_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_12_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 7,
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_13_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_13_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 4,
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_14_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_14_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "muliply",
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_1_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     },
     Plus,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_2_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     },
     Minus,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_3_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     Integer {
         literal: 9,
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_4_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_4_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     },
     Divide,
     False,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_5_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_5_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     },
     Plus,
     False,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_6_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_6_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     String {
         literal: "this is a string",
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_7_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_7_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     String {
         literal: "can't multiply",
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_8_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_8_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     },
     Divide,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_9_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_infix_expression__test_type_mismatch_integer_infix_expression_case_9_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: " cant append",
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/type_mismatch_integer_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_prefix_expression__test_type_mismatch_integer_prefix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/evaluation_error/type_mismatch_integer_prefix_expression/snapshots/monkey_interpreter__tests__evaluation_error__type_mismatch_integer_prefix_expression__test_type_mismatch_integer_prefix_expression_case_1_lexical_analysis.snap
@@ -7,5 +7,4 @@ expression: tokens
     Integer {
         literal: 5,
     },
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_1_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     False,
     Plus,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_2_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     True,
     Minus,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_3_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     True,
     Multiply,
     True,
-    EndOfFile,
 ]

--- a/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_4_lexical_analysis.snap
+++ b/src/tests/evaluation_error/unknown_operator_integer_infix_expression/snapshots/monkey_interpreter__tests__evaluation_error__unknown_operator_integer_infix_expression__test_unknown_operator_integer_infix_expression_case_4_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     False,
     Divide,
     False,
-    EndOfFile,
 ]

--- a/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_1_lexical_analysis.snap
+++ b/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_1_lexical_analysis.snap
@@ -18,5 +18,4 @@ expression: tokens
         literal: 3,
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_2_lexical_analysis.snap
+++ b/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_2_lexical_analysis.snap
@@ -24,5 +24,4 @@ expression: tokens
     SemiColon,
     ClosingCurlyBracket,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_3_lexical_analysis.snap
+++ b/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_3_lexical_analysis.snap
@@ -11,5 +11,4 @@ expression: tokens
         literal: 3,
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_4_lexical_analysis.snap
+++ b/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_4_lexical_analysis.snap
@@ -24,5 +24,4 @@ expression: tokens
     },
     SemiColon,
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_5_lexical_analysis.snap
+++ b/src/tests/fn_expression/snapshots/monkey_interpreter__tests__fn_expression__test_fn_expression_case_5_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
     ClosingRoundBracket,
     OpeningCurlyBracket,
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_10_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_10_lexical_analysis.snap
@@ -15,5 +15,4 @@ expression: tokens
     Identifier {
         literal: "flatcase",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_11_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_11_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
     Identifier {
         literal: "camelCase",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_12_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_12_lexical_analysis.snap
@@ -15,5 +15,4 @@ expression: tokens
     Identifier {
         literal: "PascalCase",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_13_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_13_lexical_analysis.snap
@@ -13,5 +13,4 @@ expression: tokens
     Identifier {
         literal: "UPPER_CASE_SNAKE_CASE",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_14_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_14_lexical_analysis.snap
@@ -24,5 +24,4 @@ expression: tokens
     Identifier {
         literal: "timeout_ms_copy",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_15_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_15_lexical_analysis.snap
@@ -23,5 +23,4 @@ expression: tokens
     Identifier {
         literal: "is_directory",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_1_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_1_lexical_analysis.snap
@@ -15,5 +15,4 @@ expression: tokens
     Identifier {
         literal: "sentence",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_2_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_2_lexical_analysis.snap
@@ -15,5 +15,4 @@ expression: tokens
     Identifier {
         literal: "csv_content",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_3_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_3_lexical_analysis.snap
@@ -27,5 +27,4 @@ expression: tokens
     Identifier {
         literal: "double",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_4_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_4_lexical_analysis.snap
@@ -30,5 +30,4 @@ expression: tokens
     Identifier {
         literal: "add",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_5_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_5_lexical_analysis.snap
@@ -15,5 +15,4 @@ expression: tokens
     Identifier {
         literal: "a",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_6_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_6_lexical_analysis.snap
@@ -24,5 +24,4 @@ expression: tokens
     Identifier {
         literal: "b",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_7_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_7_lexical_analysis.snap
@@ -13,5 +13,4 @@ expression: tokens
     Identifier {
         literal: "is_file",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_8_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_8_lexical_analysis.snap
@@ -13,5 +13,4 @@ expression: tokens
     Identifier {
         literal: "is_file",
     },
-    EndOfFile,
 ]

--- a/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_9_lexical_analysis.snap
+++ b/src/tests/identifier_expression/snapshots/monkey_interpreter__tests__identifier_expression__test_identifier_expression_case_9_lexical_analysis.snap
@@ -15,5 +15,4 @@ expression: tokens
     Identifier {
         literal: "file",
     },
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_1_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_1_lexical_analysis.snap
@@ -33,5 +33,4 @@ expression: tokens
     False,
     SemiColon,
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_2_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_2_lexical_analysis.snap
@@ -29,5 +29,4 @@ expression: tokens
         literal: 1,
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_3_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_3_lexical_analysis.snap
@@ -14,5 +14,4 @@ expression: tokens
         literal: 1,
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_4_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_4_lexical_analysis.snap
@@ -22,5 +22,4 @@ expression: tokens
     OpeningCurlyBracket,
     True,
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_5_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_5_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: 10,
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_6_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_6_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: 10,
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_7_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_7_lexical_analysis.snap
@@ -18,5 +18,4 @@ expression: tokens
         literal: 5,
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_8_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_8_lexical_analysis.snap
@@ -20,5 +20,4 @@ expression: tokens
     OpeningCurlyBracket,
     False,
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_9_lexical_analysis.snap
+++ b/src/tests/if_expression/snapshots/monkey_interpreter__tests__if_expression__test_if_expression_case_9_lexical_analysis.snap
@@ -18,5 +18,4 @@ expression: tokens
         literal: 58,
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/integer_expression/snapshots/monkey_interpreter__tests__integer_expression__test_integer_expression_case_1_lexical_analysis.snap
+++ b/src/tests/integer_expression/snapshots/monkey_interpreter__tests__integer_expression__test_integer_expression_case_1_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     Integer {
         literal: 5,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_expression/snapshots/monkey_interpreter__tests__integer_expression__test_integer_expression_case_2_lexical_analysis.snap
+++ b/src/tests/integer_expression/snapshots/monkey_interpreter__tests__integer_expression__test_integer_expression_case_2_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     Integer {
         literal: 123,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_10_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_10_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
     },
     Equals,
     False,
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_11_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_11_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
     },
     Equals,
     True,
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_12_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_12_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
     },
     Equals,
     False,
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_1_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_1_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 3,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_2_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_2_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 2,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_3_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_3_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 3,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_4_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_4_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 7,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_5_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_5_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 13,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_6_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_6_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 19,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_7_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_7_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 15,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_8_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_8_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 7,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_9_lexical_analysis.snap
+++ b/src/tests/integer_infix_boolean_expression/snapshots/monkey_interpreter__tests__integer_infix_boolean_expression__test_integer_infix_boolean_expression_case_9_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
     },
     Equals,
     True,
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_10_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_10_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
     Integer {
         literal: 3,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_11_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_11_lexical_analysis.snap
@@ -11,5 +11,4 @@ expression: tokens
     Integer {
         literal: 1,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_12_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_12_lexical_analysis.snap
@@ -14,5 +14,4 @@ expression: tokens
     Integer {
         literal: 10,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_13_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_13_lexical_analysis.snap
@@ -11,5 +11,4 @@ expression: tokens
     Integer {
         literal: 10,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_1_lexical_analysis.snap
@@ -13,5 +13,4 @@ expression: tokens
         literal: 10,
     },
     ClosingRoundBracket,
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_2_lexical_analysis.snap
@@ -17,5 +17,4 @@ expression: tokens
         literal: 10,
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_3_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 5,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_4_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_4_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 6,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_5_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_5_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 4,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_6_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_6_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Integer {
         literal: 10,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_7_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_7_lexical_analysis.snap
@@ -11,5 +11,4 @@ expression: tokens
     Integer {
         literal: 10,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_8_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_8_lexical_analysis.snap
@@ -14,5 +14,4 @@ expression: tokens
     Integer {
         literal: 10,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_9_lexical_analysis.snap
+++ b/src/tests/integer_infix_expression/snapshots/monkey_interpreter__tests__integer_infix_expression__test_integer_infix_expression_case_9_lexical_analysis.snap
@@ -14,5 +14,4 @@ expression: tokens
     Integer {
         literal: 1,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_prefix_expression/snapshots/monkey_interpreter__tests__integer_prefix_expression__test_integer_prefix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/integer_prefix_expression/snapshots/monkey_interpreter__tests__integer_prefix_expression__test_integer_prefix_expression_case_1_lexical_analysis.snap
@@ -7,5 +7,4 @@ expression: tokens
     Integer {
         literal: 5,
     },
-    EndOfFile,
 ]

--- a/src/tests/integer_prefix_expression/snapshots/monkey_interpreter__tests__integer_prefix_expression__test_integer_prefix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/integer_prefix_expression/snapshots/monkey_interpreter__tests__integer_prefix_expression__test_integer_prefix_expression_case_2_lexical_analysis.snap
@@ -7,5 +7,4 @@ expression: tokens
     Integer {
         literal: 10,
     },
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_10_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_10_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: 3,
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_11_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_11_lexical_analysis.snap
@@ -9,5 +9,4 @@ expression: tokens
     },
     Assign,
     False,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_12_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_12_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: "terrible format",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_13_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_13_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Assign,
     False,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_14_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_14_lexical_analysis.snap
@@ -21,5 +21,4 @@ expression: tokens
         literal: "timeout_ms",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_15_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_15_lexical_analysis.snap
@@ -20,5 +20,4 @@ expression: tokens
         literal: "is_file",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_1_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_1_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: "this is a multiple words...\n",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_2_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_2_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: "col_1\tcol_2\tcol_3\n",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_3_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_3_lexical_analysis.snap
@@ -24,5 +24,4 @@ expression: tokens
     },
     ClosingCurlyBracket,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_4_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_4_lexical_analysis.snap
@@ -27,5 +27,4 @@ expression: tokens
         literal: "y",
     },
     ClosingCurlyBracket,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_5_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_5_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: 5,
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_6_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_6_lexical_analysis.snap
@@ -21,5 +21,4 @@ expression: tokens
         literal: 91,
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_7_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_7_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Assign,
     True,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_8_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_8_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Assign,
     False,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_9_lexical_analysis.snap
+++ b/src/tests/let_statement/snapshots/monkey_interpreter__tests__let_statement__test_let_statement_case_9_lexical_analysis.snap
@@ -12,5 +12,4 @@ expression: tokens
         literal: "/tmp/temp.txt",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/return_statement/snapshots/monkey_interpreter__tests__return_statement__test_return_statement_case_1_lexical_analysis.snap
+++ b/src/tests/return_statement/snapshots/monkey_interpreter__tests__return_statement__test_return_statement_case_1_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
         literal: 10,
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/return_statement/snapshots/monkey_interpreter__tests__return_statement__test_return_statement_case_2_lexical_analysis.snap
+++ b/src/tests/return_statement/snapshots/monkey_interpreter__tests__return_statement__test_return_statement_case_2_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     Return,
     True,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/return_statement/snapshots/monkey_interpreter__tests__return_statement__test_return_statement_case_3_lexical_analysis.snap
+++ b/src/tests/return_statement/snapshots/monkey_interpreter__tests__return_statement__test_return_statement_case_3_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
         literal: "string123",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/string_expression/snapshots/monkey_interpreter__tests__string_expression__test_string_expression_case_1_lexical_analysis.snap
+++ b/src/tests/string_expression/snapshots/monkey_interpreter__tests__string_expression__test_string_expression_case_1_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     String {
         literal: "this is a string",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_expression/snapshots/monkey_interpreter__tests__string_expression__test_string_expression_case_2_lexical_analysis.snap
+++ b/src/tests/string_expression/snapshots/monkey_interpreter__tests__string_expression__test_string_expression_case_2_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     String {
         literal: "line1\nline2\n",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_expression/snapshots/monkey_interpreter__tests__string_expression__test_string_expression_case_3_lexical_analysis.snap
+++ b/src/tests/string_expression/snapshots/monkey_interpreter__tests__string_expression__test_string_expression_case_3_lexical_analysis.snap
@@ -6,5 +6,4 @@ expression: tokens
     String {
         literal: "column-1\tcolumn-2\n",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_1_lexical_analysis.snap
+++ b/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_1_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "name",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_2_lexical_analysis.snap
+++ b/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_2_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "this is a string",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_3_lexical_analysis.snap
+++ b/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_3_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "last",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_4_lexical_analysis.snap
+++ b/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_4_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "\tstring123",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_5_lexical_analysis.snap
+++ b/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_5_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "string123",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_6_lexical_analysis.snap
+++ b/src/tests/string_infix_boolean_expression/snapshots/monkey_interpreter__tests__string_infix_boolean_expression__test_string_infix_boolean_expression_case_6_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "name123",
     },
-    EndOfFile,
 ]

--- a/src/tests/string_infix_expression/snapshots/monkey_interpreter__tests__string_infix_expression__test_string_infix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/string_infix_expression/snapshots/monkey_interpreter__tests__string_infix_expression__test_string_infix_expression_case_1_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     String {
         literal: "456",
     },
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_boolean_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_boolean_prefix_expression__test_invalid_boolean_prefix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_boolean_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_boolean_prefix_expression__test_invalid_boolean_prefix_expression_case_1_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Assign,
     Not,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_boolean_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_boolean_prefix_expression__test_invalid_boolean_prefix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_boolean_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_boolean_prefix_expression__test_invalid_boolean_prefix_expression_case_2_lexical_analysis.snap
@@ -4,5 +4,4 @@ expression: tokens
 ---
 [
     Not,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_boolean_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_boolean_prefix_expression__test_invalid_boolean_prefix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_boolean_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_boolean_prefix_expression__test_invalid_boolean_prefix_expression_case_3_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Assign,
     Not,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_integer_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_integer_prefix_expression__test_invalid_integer_prefix_expression_case_1_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_integer_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_integer_prefix_expression__test_invalid_integer_prefix_expression_case_1_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Assign,
     Minus,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_integer_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_integer_prefix_expression__test_invalid_integer_prefix_expression_case_2_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_integer_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_integer_prefix_expression__test_invalid_integer_prefix_expression_case_2_lexical_analysis.snap
@@ -4,5 +4,4 @@ expression: tokens
 ---
 [
     Minus,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_integer_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_integer_prefix_expression__test_invalid_integer_prefix_expression_case_3_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_integer_prefix_expression/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_integer_prefix_expression__test_invalid_integer_prefix_expression_case_3_lexical_analysis.snap
@@ -10,5 +10,4 @@ expression: tokens
     Assign,
     Minus,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_1_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_1_lexical_analysis.snap
@@ -9,5 +9,4 @@ expression: tokens
     },
     Assign,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_2_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_2_lexical_analysis.snap
@@ -4,5 +4,4 @@ expression: tokens
 ---
 [
     Let,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_3_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_3_lexical_analysis.snap
@@ -8,5 +8,4 @@ expression: tokens
         literal: "file",
     },
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_4_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_4_lexical_analysis.snap
@@ -7,5 +7,4 @@ expression: tokens
     Identifier {
         literal: "flatcase",
     },
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_5_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_5_lexical_analysis.snap
@@ -7,5 +7,4 @@ expression: tokens
     Identifier {
         literal: "camelCase",
     },
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_6_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_6_lexical_analysis.snap
@@ -7,5 +7,4 @@ expression: tokens
     Identifier {
         literal: "PascalCase",
     },
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_7_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_7_lexical_analysis.snap
@@ -9,5 +9,4 @@ expression: tokens
     },
     Assign,
     SemiColon,
-    EndOfFile,
 ]

--- a/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_8_lexical_analysis.snap
+++ b/src/tests/syntax_analysis_error/invalid_let_statement/snapshots/monkey_interpreter__tests__syntax_analysis_error__invalid_let_statement__test_invalid_let_statement_case_8_lexical_analysis.snap
@@ -17,5 +17,4 @@ expression: tokens
         literal: "timeout_ms_copy",
     },
     SemiColon,
-    EndOfFile,
 ]


### PR DESCRIPTION
It provides no value or functionality, the end of the iterator already indicated the ending of a file. Having the end of an iterator and a token makes it more complex.